### PR TITLE
add --key-normalize-regexp option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ tcpdump will exit after number of this option seconds.
 * ```-d```, ```--debug```  
 increase debug level. ```-d -d``` more verbosely.
 
+* ```-k```, ```--key-normalize-regexp```
+Replace parts of key to '*' with regexp.
+
 ## INSTALLATION
 
 ### QUICK TRIAL for CentOS 6

--- a/script/redis-traffic-stats
+++ b/script/redis-traffic-stats
@@ -53,6 +53,7 @@ MAIN: {
         'device|i=s',
         'count|c=i',
         'time|t=i',
+        'key-normalize-regexp|k=s',
         'debug|d+' => \$Debug,
         'help|h|?' => sub { pod2usage(-verbose=>1) },
     ) or pod2usage();
@@ -119,7 +120,7 @@ MAIN: {
     progressln(" done ($count pkt)");
 
     progress("process Redis protocol ");
-    my $stats = process_redis($stream);
+    my $stats = process_redis($stream, $opt->{"key-normalize-regexp"});
     progressln(" done");
     debug("stats: ".Dumper($stats));
 
@@ -225,7 +226,7 @@ sub process_packet {
 }
 
 sub process_redis {
-    my($stream) = @_;
+    my($stream, $normalize) = @_;
 
     my %stats = (
         start => 1<<31,
@@ -281,6 +282,7 @@ sub process_redis {
             $stats{cmd}{$cmd}{bytes} += length( $cmd{res} );
             if ($cmd{req}[1]) {
                 my $key = $cmd{req}[1];
+                $key =~ s{$normalize}{*}og if defined $normalize;
                 $stats{cmd}{$cmd}{key}{$key}{count}++;
                 $stats{cmd}{$cmd}{key}{$key}{bytes} += length( $cmd{res} );
             }


### PR DESCRIPTION
Hi.

I added `--key-normalize-regexp` option.
Replace parts of key matched with regexp to `*`.

For example,

Before:
```
Key                                                                     | Bytes     | Byte/sec     | Count  | Pct    | Req/sec
------------------------------------------------------------------------|----------:|-------------:|-------:|-------:|---------:
sess:849c61a11362b12e67a1193de4a8dd18e254baf2cf27fb4ff1f7d9a5e63db423   |       384 |         8.53 |     12 |   0.11 |     0.27
sess:0580b4d3f9c48c3a0f7c0aaba5dbe8df547fdcab6744b2bdb0e12a54c6b6dbed   |       352 |         7.82 |     11 |   0.10 |     0.24
sess:1a9f46f189578e0f5727bf0ee04fc417cbe407332b4aca7afcb7816abd4abb19   |       352 |         7.82 |     11 |   0.10 |     0.24
```

After:   with `-k '[0-9a-f]{16,}'`
```
Key                                            | Bytes     | Byte/sec     | Count  | Pct    | Req/sec
-----------------------------------------------|----------:|-------------:|-------:|-------:|---------:
sess:*                                         |    256192 |      5693.16 |   8006 |  74.93 |   177.91
```